### PR TITLE
Don't track user location after map dispose on iOS

### DIFF
--- a/src/ios/ESMap.m
+++ b/src/ios/ESMap.m
@@ -417,6 +417,7 @@
 }
 
 - (void)destroy {
+    _map.showsUserLocation = NO;
     for (ESMarker *marker in self.map.annotations) {
         [marker destroy];
     }


### PR DESCRIPTION
Core Location tracks the user location continuously as long as 
the `showsUserLocation` flag is set to `YES`. Disable it on 
map dispose.

See [`showsUserLocation`](https://developer.apple.com/reference/mapkit/mkmapview/1452682-showsuserlocation).

Fix iOS part of https://github.com/eclipsesource/tabris-plugin-maps/issues/20