### PR TITLE
Use Google Maven repo to resolve project dependencies

### DIFF
--- a/project/android/build.gradle
+++ b/project/android/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
+        maven { url 'https://maven.google.com' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.0'
@@ -12,6 +13,7 @@ allprojects {
     repositories {
         jcenter()
         mavenCentral()
+        maven { url 'https://maven.google.com' }
         maven {
             // provides tabris from directory repository
             url new File(System.getenv('TABRIS_ANDROID_PLATFORM') +


### PR DESCRIPTION
Support library dependencies of tabris-android are now resolved from
maven.google.com.

Change-Id: I62964f8d629d8013cb970bc4c179874e5ec964aa