### PR TITLE
Fire cameraMoved consistently for user interactions

### DIFF
--- a/src/android/com/eclipsesource/tabris/maps/MapCameraChangeListener.java
+++ b/src/android/com/eclipsesource/tabris/maps/MapCameraChangeListener.java
@@ -33,7 +33,8 @@ public class MapCameraChangeListener implements OnCameraMoveStartedListener, OnC
   public void onCameraIdle() {
     CameraPosition cameraPosition = mapHolderView.getGoogleMap().getCameraPosition();
     notifyChangeCameraEvent(cameraPosition);
-    if (reason == OnCameraMoveStartedListener.REASON_GESTURE) {
+    if (reason == OnCameraMoveStartedListener.REASON_GESTURE ||
+        reason == OnCameraMoveStartedListener.REASON_API_ANIMATION) {
       notifyCameraMoveEvent(cameraPosition);
     }
   }


### PR DESCRIPTION
Previously e.g. interactions with the "show my location" button did not
trigger "cameraMove", although they were initiated by the user.

The reason REASON_API_ANIMATION will be set when a non-gesture animation
has been initiated in response to user actions [1].

[1]: https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnCameraMoveStartedListener.html#REASON_API_ANIMATION

Change-Id: Ib11d242fe55c20fe5831106251fd5ac906905579