### PR TITLE
Fix some example issues

### DIFF
--- a/example/src/pages/CameraPage.js
+++ b/example/src/pages/CameraPage.js
@@ -13,7 +13,7 @@ class CameraPage extends Page {
 
   _createUI() {
     let controls = new Composite({
-      left: 0, right: 0, bottom: 0,
+      left: 0, right: 0, bottom: 0, height: 144,
       background: 'white',
       elevation: 6
     }).appendTo(this);
@@ -40,7 +40,7 @@ class CameraPage extends Page {
 
     this._statusLabel = new TextView({
       id: 'label',
-      left: 16, right: 16, top: [paris, 16], bottom: 16,
+      left: 16, right: 16, bottom: 20,
       lineSpacing: 1.2,
       markupEnabled: true
     }).appendTo(controls);

--- a/example/src/pages/MarkerPage.js
+++ b/example/src/pages/MarkerPage.js
@@ -13,7 +13,7 @@ class MarkerPage extends Page {
 
   _createUI() {
     let controls = new Composite({
-      left: 0, right: 0, bottom: 0,
+      left: 0, right: 0, bottom: 0, height: 64,
       background: 'white',
       elevation: 6
     }).appendTo(this);

--- a/example/src/pages/PositionPage.js
+++ b/example/src/pages/PositionPage.js
@@ -13,7 +13,7 @@ class PositionPage extends Page {
 
   _createUI() {
     let controls = new Composite({
-      left: 0, right: 0, bottom: 0,
+      left: 0, right: 0, bottom: 0, height: 144,
       background: 'white',
       elevation: 6
     }).appendTo(this);
@@ -39,12 +39,12 @@ class PositionPage extends Page {
 
     let updatePositionButton = new Button({
       text: 'Get position',
-      left: 16, top: [paris, 16], bottom: 16
+      left: 16, bottom: 16
     }).on('select', () => this._updatePositionLabel())
       .appendTo(controls);
 
     this._positionLabel = new TextView({
-      left: [updatePositionButton, 16], right: 16, top: [paris, 16], bottom: 16,
+      left: [updatePositionButton, 16], right: 16, bottom: 20,
       markupEnabled: true
     }).appendTo(controls);
   }

--- a/example/src/pages/RegionPage.js
+++ b/example/src/pages/RegionPage.js
@@ -13,7 +13,7 @@ class RegionPage extends Page {
 
   _createUI() {
     let controls = new Composite({
-      left: 0, right: 0, bottom: 0,
+      left: 0, right: 0, bottom: 0, height: 152,
       background: 'white',
       elevation: 6
     }).appendTo(this);
@@ -37,11 +37,11 @@ class RegionPage extends Page {
       left: '50% 8', right: 16, top: 16,
       text: 'Show Sydney'
     }).on('select', () => {
-      map.region = {southWest: [-33.912452, 151.1260233], northEast: [-33.785166, 151.2875383]};
+      this._map.region = {southWest: [-33.912452, 151.1260233], northEast: [-33.785166, 151.2875383]};
     }).appendTo(controls);
 
     this._regionLabel = new TextView({
-      left: 16, right: 16, top: [paris, 16], bottom: 16,
+      left: 16, right: 16, bottom: 16,
       lineSpacing: 1.2,
       markupEnabled: true
     }).appendTo(controls);


### PR DESCRIPTION
Workaround some layouting bugs present in Tabris.js 2.0:

* give controls container fixed height to prevent unexpected layout on Android
* remove top layout reference of some widgets to prevent referenced widget from unexpectedly growing in height on iOS

Also fix a bad variable reference in RegionPage.