### PR TITLE
Improve project and example READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ new esmaps.Map({
 }).appendTo(tabris.ui.contentView);
 ```
 
-A more elaborate example can be found in the [example](example/) folder. It provides a Tabris.js cordova project that demonstrates the various features of the `tabris-plugin-maps` widget. When building the example project don't forget to run `npm install` inside the `www` folder to fetch the Tabris.js dependencies.
+A more elaborate example can be found in the [example](example/) folder. It provides a Tabris.js app that demonstrates various features of the `tabris-plugin-maps` widget.
 
 ## Integrating the plugin
-Using the plugin follows the standard cordova plugin mechanism. The Tabris.js website provides detailed information on how to [integrate custom widgets](https://tabrisjs.com/documentation/latest/build#adding-plugins) in your Tabris.js based app.
+The Tabris.js website provides detailed information on how to [integrate custom widgets](https://tabrisjs.com/documentation/latest/build#adding-plugins) in your Tabris.js based app.
 
 ### Add the plugin to your project
 
@@ -38,21 +38,17 @@ To fetch the latest development version use the GitHub url:
 
 #### Android
 
-On Android a Google Maps API key has to be provided when adding the plugin to your Cordova project. The documentation for the Google Maps API explains how to [acquire an API key](https://developers.google.com/maps/documentation/android/signup).
+On Android a Google Maps API key has to be provided when adding the plugin to your Tabris.js app. The documentation for the Google Maps API explains how to [acquire an API key](https://developers.google.com/maps/documentation/android/signup).
 
-The API key can be configured inside your apps `config.xml`:
+The API key can be configured inside your app's `config.xml`:
 
 ```xml
 <plugin name="tabris-plugin-maps" spec="3.0.0">
-  <variable name="ANDROID_API_KEY" value="your-android-maps-api-key" />
+  <variable name="ANDROID_API_KEY" value="$ANDROID_API_KEY" />
 </plugin>
 ```
 
-Alternatively the API key can be added during the `cordova plugin add` command:
-
-```bash
-cordova plugin add <path-to-tabris-maps-plugin> --variable ANDROID_API_KEY=`your-android-maps-api-key`
-```
+When the environment variable `ANDROID_API_KEY` is set, Tabris.js CLI will replace the value placeholder `$ANDROID_API_KEY` in the config.xml during build.
 
 ## API documentation
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,28 +1,21 @@
 # Tabris.js Maps Example
 
 ## Prerequisites
-
-To run the example it is recommended to use the [tabris-cli](https://www.npmjs.com/package/tabris-cli). The tabris-cli requires a local [Tabris.js platform](https://tabrisjs.com/download) which should be referenced by a corresponding environment variable.
+To run the example it is recommended to use the [Tabris.js CLI](https://www.npmjs.com/package/tabris-cli).
 
 ### Android
-Running the example on Android requires a valid Google Maps API key. The documentation for the Google Maps API explains how to [acquire an API key](https://developers.google.com/maps/documentation/android/signup). It can be configured in the `config.xml`:
-
-```
-<plugin name="tabris-plugin-maps" spec="<version-or-path>">
-  <variable name="ANDROID_API_KEY" value="<google-maps-api-key>" />
-</plugin>
-```
+Running the example on Android requires a valid Google Maps API key. The documentation for the Google Maps API explains how to [acquire an API key](https://developers.google.com/maps/documentation/android/signup).
 
 ## Running the Example
 
-Using the tabris-cli the example can be started by running:
+Using the Tabris.js CLI the example can be started by running:
 
 ```sh
 $ tabris run <platform>
 ```
 
-When running this example on Android, the Google Maps API key can also be provided via a command line option. The tabris-cli will replace the placeholder in the config.xml with the given API key:
+When running this example on Android, the Google Maps API key can also be provided by setting an environment variable. The Tabris.js CLI will replace the placeholder in the config.xml with the given API key:
 
 ```sh
-$ tabris run <platform> --variables ANDROID_API_KEY=<google-maps-api-key>
+$ ANDROID_API_KEY=<google-maps-api-key> tabris run android
 ```


### PR DESCRIPTION
* Reduce references to Cordova, since Tabris.js CLI encapsulates it.
* Remove recommendation to run "npm install", since "tabris run" does this already.
* Recommend using environment variables over the Tabris.js CLI '--variables' option, since the API key should not land in the shell history. Environment variables can also be set by the Tabris.js build service.
* Use "Tabris.js CLI" instead of "tabris-cli" consistently.
* Remove redundant config.xml snippet from the example README, this is already documented in the README of the plugin.

Change-Id: If7125a8effa1545bdae140257cd602aafa1addd9