### PR TITLE
Fix example page titles on iOS

### DIFF
--- a/example/src/app.js
+++ b/example/src/app.js
@@ -17,7 +17,7 @@ PAGES.forEach(createPageButton);
 function createPageButton(PageConstructor) {
   new Button({
     left: 16, top: 'prev() 16', right: 16,
-    text: 'Show \'' + PageConstructor.name.toLowerCase() + '\' example'
+    text: 'Show \'' + PageConstructor.NAME.toLowerCase() + '\' example'
   }).on('select', () => new PageConstructor().appendTo(navigationView))
     .appendTo(mainPage);
 }

--- a/example/src/pages/CameraPage.js
+++ b/example/src/pages/CameraPage.js
@@ -3,11 +3,11 @@ const {Button, Composite, Page, TextView} = require('tabris');
 class CameraPage extends Page {
 
   constructor() {
-    super({title: CameraPage.name});
+    super({title: CameraPage.NAME});
     this._createUI();
   }
 
-  static get name() {
+  static get NAME() {
     return 'Camera';
   }
 

--- a/example/src/pages/MarkerPage.js
+++ b/example/src/pages/MarkerPage.js
@@ -3,11 +3,11 @@ const {Composite, Page, TextView} = require('tabris');
 class MarkerPage extends Page {
 
   constructor() {
-    super({title: MarkerPage.name});
+    super({title: MarkerPage.NAME});
     this._createUI();
   }
 
-  static get name() {
+  static get NAME() {
     return 'Marker';
   }
 

--- a/example/src/pages/PositionPage.js
+++ b/example/src/pages/PositionPage.js
@@ -3,11 +3,11 @@ const {Button, Composite, Page, TextView} = require('tabris');
 class PositionPage extends Page {
 
   constructor() {
-    super({title: PositionPage.name});
+    super({title: PositionPage.NAME});
     this._createUI();
   }
 
-  static get name() {
+  static get NAME() {
     return 'Position';
   }
 

--- a/example/src/pages/RegionPage.js
+++ b/example/src/pages/RegionPage.js
@@ -3,11 +3,11 @@ const {Button, Composite, Page, TextView} = require('tabris');
 class RegionPage extends Page {
 
   constructor() {
-    super({title: RegionPage.name});
+    super({title: RegionPage.NAME});
     this._createUI();
   }
 
-  static get name() {
+  static get NAME() {
     return 'Region';
   }
 


### PR DESCRIPTION
Static page class getter 'name' was colliding with the function property
'name'. On Android, the static class getter overwrote the function
property, but on iOS it didn't, which resulted in the class constructor
name instead of the given page name being displayed.

Use capital case for the property to designate it as static and thus
prevent collision with the function property 'name'.

Change-Id: I1943e9e32f6dfd2bfbf2eb28fb45adff6e8d8551