### PR TITLE
Support marker image property on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ A `Marker` is used to indicate places and positions on the Map.
 
 ##### `image` : _Image_
 
-* Image to be shown instead of the standard marker image.
+* Image to be shown instead of the standard marker image. *Cannot be changed on iOS once the marker has been rendered.*
 
 #### Events
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ A `Marker` is used to indicate places and positions on the Map.
 
 ##### `image` : _Image_
 
-* Image to be shown instead of the standard marker image. *Cannot be changed on iOS once the marker has been rendered.*
+* Image to be shown instead of the standard marker image.
 
 #### Events
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -88,6 +88,7 @@
     <source-file src="src/ios/ESMap.m" />
     <header-file src="src/ios/ESMarker.h" />
     <source-file src="src/ios/ESMarker.m" />
+    <header-file src="src/ios/UIImageView+Tabris.h" />
 
     <!-- Required frameworks -->
     <framework src="MapKit.framework" />

--- a/src/ios/ESMap.h
+++ b/src/ios/ESMap.h
@@ -25,4 +25,5 @@
 - (void)addMarker:(NSDictionary *)properties;
 - (void)removeMarker:(NSDictionary *)properties;
 - (void)moveToRegion: (NSDictionary *)properties;
+- (void)refreshMarker:(ESMarker *)marker;
 @end

--- a/src/ios/ESMap.m
+++ b/src/ios/ESMap.m
@@ -337,6 +337,7 @@
 
 - (void)addMarker:(NSDictionary *)properties {
     ESMarker *marker = [self getMarkerFrom:properties];
+    marker.map = self;
     if (marker) {
         [self.map addAnnotation:(ESMarker *) marker];
     }
@@ -450,6 +451,11 @@
         view.image = nil;
         markerViewHolder = nil;
     }];
+}
+
+- (void) refreshMarker:(ESMarker *)marker {
+    [self.map removeAnnotation:marker];
+    [self.map addAnnotation:marker];
 }
 
 - (void)destroy {

--- a/src/ios/ESMap.m
+++ b/src/ios/ESMap.m
@@ -8,6 +8,7 @@
 
 #import "ESMap.h"
 #import "ESMarker.h"
+#import "UIImageView+Tabris.h"
 #import <MapKit/MapKit.h>
 
 @interface MKMapView (Tabris)
@@ -414,6 +415,41 @@
     }
     ESMarker *marker = (ESMarker *)view.annotation;
     [marker tapped];
+}
+
+- (MKAnnotationView *)mapView:(MKMapView *)mapView viewForAnnotation:(id<MKAnnotation>)annotation {
+    if (![annotation isKindOfClass:[ESMarker class]]) {
+        return nil;
+    }
+    NSArray* image = ((ESMarker *) annotation).image;
+    NSString* reuseIdentifier = image ? [image objectAtIndex:0] : @"pin";
+    MKAnnotationView *view = [mapView dequeueReusableAnnotationViewWithIdentifier:reuseIdentifier];
+    if (view) {
+        view.annotation = annotation;
+        return view;
+    }
+    return [self createAnnotationView:annotation reuseIdentifier:reuseIdentifier image:image];
+}
+
+- (MKAnnotationView*)createAnnotationView:(id<MKAnnotation>)annotation reuseIdentifier:(NSString*)reuseIdentifier image:(NSArray *)image {
+    if (image) {
+        MKAnnotationView* view = [[MKAnnotationView alloc] initWithAnnotation:annotation reuseIdentifier:reuseIdentifier];
+        [self setAnnotationViewImage:view image:image];
+        return view;
+    } else {
+        return [[MKPinAnnotationView alloc] initWithAnnotation:annotation reuseIdentifier:reuseIdentifier];
+    }
+}
+
+- (void)setAnnotationViewImage:(MKAnnotationView *)view image: (NSArray *) image {
+    __block UIImageView *markerViewHolder = [[UIImageView alloc] init];
+    [markerViewHolder setImageWithProperties:image client:self.client success:^(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *uiImage) {
+        view.image = uiImage;
+        markerViewHolder = nil;
+    } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
+        view.image = nil;
+        markerViewHolder = nil;
+    }];
 }
 
 - (void)destroy {

--- a/src/ios/ESMarker.h
+++ b/src/ios/ESMarker.h
@@ -11,7 +11,7 @@
 #import <MapKit/MapKit.h>
 
 @interface ESMarker : BasicWidget <MKAnnotation>
-@property (strong) ESMap *map;
+@property (weak) ESMap *map;
 @property (strong) NSArray *position;
 @property (strong) NSArray *image;
 @property (assign) BOOL tapListener;

--- a/src/ios/ESMarker.h
+++ b/src/ios/ESMarker.h
@@ -11,6 +11,7 @@
 
 @interface ESMarker : BasicWidget <MKAnnotation>
 @property (strong) NSArray *position;
+@property (strong) NSArray *image;
 @property (assign) BOOL tapListener;
 - (void)tapped;
 @end

--- a/src/ios/ESMarker.h
+++ b/src/ios/ESMarker.h
@@ -6,10 +6,12 @@
 //
 //
 
+#import "ESMap.h"
 #import <Tabris/BasicWidget.h>
 #import <MapKit/MapKit.h>
 
 @interface ESMarker : BasicWidget <MKAnnotation>
+@property (strong) ESMap *map;
 @property (strong) NSArray *position;
 @property (strong) NSArray *image;
 @property (assign) BOOL tapListener;

--- a/src/ios/ESMarker.m
+++ b/src/ios/ESMarker.m
@@ -74,9 +74,5 @@
     _coordinate = newCoordinate;
 }
 
--(void)destroy {
-    self.map = nil;
-    [super destroy];
-}
 
 @end

--- a/src/ios/ESMarker.m
+++ b/src/ios/ESMarker.m
@@ -9,10 +9,6 @@
 #import "ESMarker.h"
 #import "ESMap.h"
 
-@interface ESMarker ()
-@property (weak) ESMap *map;
-@end
-
 @implementation ESMarker
 
 @synthesize position = _position;
@@ -20,7 +16,7 @@
 @synthesize coordinate = _coordinate;
 @synthesize title = _title;
 @synthesize subtitle = _subtitle;
-@synthesize map = _map;
+@synthesize image = _image;
 
 - (instancetype)initWithObjectId:(NSString *)objectId properties:(NSDictionary *)properties andClient:(TabrisClient *)client {
     self = [super initWithObjectId:objectId properties:properties andClient:client];

--- a/src/ios/ESMarker.m
+++ b/src/ios/ESMarker.m
@@ -17,6 +17,7 @@
 @synthesize title = _title;
 @synthesize subtitle = _subtitle;
 @synthesize image = _image;
+@synthesize map = _map;
 
 - (instancetype)initWithObjectId:(NSString *)objectId properties:(NSDictionary *)properties andClient:(TabrisClient *)client {
     self = [super initWithObjectId:objectId properties:properties andClient:client];
@@ -35,6 +36,17 @@
         [self setCoordinate:CLLocationCoordinate2DMake(0, 0)];
     }
     return self;
+}
+
+-(void)setImage:(NSArray *)image {
+    _image = image;
+    if (self.map) {
+        [self.map refreshMarker: self];
+    }
+}
+
+-(NSArray *)image {
+    return _image;
 }
 
 - (UIView *)view {
@@ -60,6 +72,11 @@
 
 - (void)setCoordinate:(CLLocationCoordinate2D)newCoordinate {
     _coordinate = newCoordinate;
+}
+
+-(void)destroy {
+    self.map = nil;
+    [super destroy];
 }
 
 @end

--- a/src/ios/UIImageView+Tabris.h
+++ b/src/ios/UIImageView+Tabris.h
@@ -1,0 +1,10 @@
+@class TabrisClient;
+
+@interface UIImageView (Tabris)
+
+- (void)setImageWithProperties:(NSArray *)imageProperties
+                        client:(TabrisClient *)client
+                       success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
+                       failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
+
+@end


### PR DESCRIPTION
View types to be cached defined according to the annotation image, since
it is the only property configured on the view.

Remove unused map property on ESMarker.

Note: this change includes usage of internal Tabris.js API which may
change in the future.

Change-Id: I22068d029378474f016f428d565b4deae6757348