### PR TITLE
Bump example version to 2.3.0

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -3,6 +3,6 @@
   "description": "Example for the Tabris maps custom widget.",
   "main": "src/app.js",
   "dependencies": {
-    "tabris": "2.0.0"
+    "tabris": "2.3.0"
   }
 }


### PR DESCRIPTION
The plugin is not compatible with Tabris.js 2.0.0 anymore on iOS.