### PR TITLE
Update compatibility section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ A `Marker` is used to indicate places and positions on the Map.
 
 ## Compatibility
 
-Compatible with [Tabris.js 2.0.0](https://github.com/eclipsesource/tabris-js/releases/tag/v2.0.0)
+Compatible with [Tabris.js 2.2.0](https://github.com/eclipsesource/tabris-js/releases/tag/v2.2.0)
 
 ## Development of the widget
 


### PR DESCRIPTION
Due to breaking changes in the custom widget hook on iOS introduced with
Tabris.js 2.2.0, the maps plugin is not compatible with 2.0.0 anymore.
