### PR TITLE
Fix marker images scale on Android

### DIFF
--- a/src/android/com/eclipsesource/tabris/maps/MarkerPropertyHandler.java
+++ b/src/android/com/eclipsesource/tabris/maps/MarkerPropertyHandler.java
@@ -73,9 +73,6 @@ public class MarkerPropertyHandler<T extends MapMarker> implements PropertyHandl
   }
 
   private Bitmap drawableToBitmap(Drawable drawable) {
-    if (drawable instanceof BitmapDrawable) {
-      return ((BitmapDrawable) drawable).getBitmap();
-    }
     Canvas canvas = new Canvas();
     Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
     canvas.setBitmap(bitmap);


### PR DESCRIPTION
It seems the Marker renderer does not support scaled bitmaps. Always create the bitmap explicitly with a fixed size.