### PR TITLE
Use AnyProperty for image processing property

### DIFF
--- a/src/android/com/eclipsesource/tabris/maps/MarkerImageProperty.kt
+++ b/src/android/com/eclipsesource/tabris/maps/MarkerImageProperty.kt
@@ -5,11 +5,11 @@ import android.graphics.Canvas
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import com.eclipsesource.tabris.android.ActivityScope
-import com.eclipsesource.tabris.android.V8ArrayProperty
+import com.eclipsesource.tabris.android.AnyProperty
 import com.eclipsesource.tabris.android.internal.image.Image
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 
-class MarkerImageProperty(private val scope: ActivityScope) : V8ArrayProperty<MapMarker>("image", {
+class MarkerImageProperty(private val scope: ActivityScope) : AnyProperty<MapMarker>("image", {
   if (it == null) {
     icon = null
   } else {


### PR DESCRIPTION
Marker images are not displayed with the old array-based syntax in the MarkerImageProperty. The change solves the issue by replacing it with an object-based format.