### PR TITLE
Fix app crash in Tabris 3.5 version

### DIFF
--- a/project/android/maps/build.gradle
+++ b/project/android/maps/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 dependencies {
-    implementation 'com.eclipsesource.tabris.android:tabris:3.2.0'
+    implementation 'com.eclipsesource.tabris.android:tabris:3.5.0'
     implementation 'com.google.android.gms:play-services-maps:17.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
@@ -23,6 +23,10 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 
     sourceSets {

--- a/src/android/com/eclipsesource/tabris/maps/MapHandler.kt
+++ b/src/android/com/eclipsesource/tabris/maps/MapHandler.kt
@@ -37,7 +37,7 @@ open class MapHandler(private val scope: ActivityScope) : ViewHandler<MapHolderV
     super.listen(id, mapHolderView, event, listen)
     when (event) {
       "ready" -> if (listen) {
-        mapHolderView.setOnMapReadyListener()
+        mapHolderView.ensureOnMapReadyListener()
       } else {
         throw IllegalStateException("'ready' event listeners cannot be removed.")
       }

--- a/src/android/com/eclipsesource/tabris/maps/MapHolderView.kt
+++ b/src/android/com/eclipsesource/tabris/maps/MapHolderView.kt
@@ -37,11 +37,11 @@ class MapHolderView(private val scope: ActivityScope) : FrameLayout(scope.activi
   }
 
   private fun createMap() {
-    mapFragment = SupportMapFragment().also {
+    mapFragment = SupportMapFragment().apply {
       scope.activity
           .supportFragmentManager
           .beginTransaction()
-          .add(id, it)
+          .add(id, this)
           .commit()
     }
   }

--- a/src/android/com/eclipsesource/tabris/maps/MapHolderView.kt
+++ b/src/android/com/eclipsesource/tabris/maps/MapHolderView.kt
@@ -12,8 +12,9 @@ import com.google.android.gms.maps.SupportMapFragment
 @SuppressLint("ViewConstructor")
 class MapHolderView(private val scope: ActivityScope) : FrameLayout(scope.activity), OnMapReadyCallback {
 
-  private lateinit var mapFragment: SupportMapFragment
+  private var mapFragment: SupportMapFragment? = null
   private var _googleMap: GoogleMap? = null
+  private var mapReadyListenerRequired = false
 
   var googleMap: GoogleMap
     set(value) {
@@ -25,20 +26,36 @@ class MapHolderView(private val scope: ActivityScope) : FrameLayout(scope.activi
 
   init {
     id = View.generateViewId()
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
     createMap()
+    if (mapReadyListenerRequired) {
+      attachOnMapReadyListener()
+    }
   }
 
   private fun createMap() {
-    mapFragment = SupportMapFragment()
-    scope.activity
-        .supportFragmentManager
-        .beginTransaction()
-        .add(id, mapFragment)
-        .commit()
+    mapFragment = SupportMapFragment().also {
+      scope.activity
+          .supportFragmentManager
+          .beginTransaction()
+          .add(id, it)
+          .commit()
+    }
   }
 
-  fun setOnMapReadyListener() {
-    mapFragment.getMapAsync(this)
+  fun ensureOnMapReadyListener() {
+    mapReadyListenerRequired = true
+    attachOnMapReadyListener()
+  }
+
+  private fun attachOnMapReadyListener() {
+    mapFragment?.let {
+      it.getMapAsync(this)
+      mapReadyListenerRequired = false
+    }
   }
 
   override fun onMapReady(googleMap: GoogleMap) {


### PR DESCRIPTION
The plugin crashes the app when we use it with the Tabris 3.5 version on Android. The issue occurs due to SupportMapFragment which is added before MapHolderView was attached to the parent.

The change solves the problem and also updates the configuration file to make the project compatible with Tabris 3.x.