### PR TITLE
Fix unrendered MapHolderView issue

### DIFF
--- a/src/android/com/eclipsesource/tabris/maps/MapHolderView.kt
+++ b/src/android/com/eclipsesource/tabris/maps/MapHolderView.kt
@@ -37,11 +37,11 @@ class MapHolderView(private val scope: ActivityScope) : FrameLayout(scope.activi
   }
 
   private fun createMap() {
-    mapFragment = SupportMapFragment().apply {
+    mapFragment = SupportMapFragment().also {
       scope.activity
           .supportFragmentManager
           .beginTransaction()
-          .add(id, this)
+          .add(id, it)
           .commit()
     }
   }


### PR DESCRIPTION
MapHolderView is not rendered due to improper use of the Kotlin function. The change updates the function in order to solve the issue.