### PR TITLE
Fix custom markers not showing up on iOS

### DIFF
--- a/src/ios/ESMap.m
+++ b/src/ios/ESMap.m
@@ -410,8 +410,9 @@
     if (![annotation isKindOfClass:[ESMarker class]]) {
         return nil;
     }
-    NSArray* image = ((ESMarker *) annotation).image;
-    NSString* reuseIdentifier = image ? [image objectAtIndex:0] : @"pin";
+
+    NSObject* image = ((ESMarker *) annotation).image;
+    NSString* reuseIdentifier = [self reuseIdentifierForImage:image] ?: @"pin";
     MKAnnotationView *view = [mapView dequeueReusableAnnotationViewWithIdentifier:reuseIdentifier];
     if (view) {
         view.annotation = annotation;
@@ -420,7 +421,18 @@
     return [self createAnnotationView:annotation reuseIdentifier:reuseIdentifier image:image];
 }
 
-- (MKAnnotationView*)createAnnotationView:(id<MKAnnotation>)annotation reuseIdentifier:(NSString*)reuseIdentifier image:(NSArray *)image {
+- (NSString*)reuseIdentifierForImage:(NSObject*)imageObject {
+    if ([imageObject isKindOfClass:[NSArray class]]) {
+        NSArray* imageArray = ((NSArray*)imageObject);
+        return imageArray.count ? [imageArray objectAtIndex:0] : nil;
+    } else if ([imageObject isKindOfClass:[NSDictionary class]]) {
+        NSDictionary* imageDictionary = ((NSDictionary*)imageObject);
+        return [imageDictionary objectForKey:@"src"];
+    }
+    return nil;
+}
+
+- (MKAnnotationView*)createAnnotationView:(id<MKAnnotation>)annotation reuseIdentifier:(NSString*)reuseIdentifier image:(NSObject *)image {
     if (image) {
         MKAnnotationView* view = [[MKAnnotationView alloc] initWithAnnotation:annotation reuseIdentifier:reuseIdentifier];
         [self setAnnotationViewImage:view image:image];
@@ -430,7 +442,7 @@
     }
 }
 
-- (void)setAnnotationViewImage:(MKAnnotationView *)view image: (NSArray *) image {
+- (void)setAnnotationViewImage:(MKAnnotationView *)view image: (NSObject *) image {
     __block TabrisImage *tabrisImage = [[TabrisImage alloc] initWithTabrisContext:self.context propertiesObject:image];
     [tabrisImage getImage:^(UIImage *uiImage, NSError *error) {
         view.image = error ? nil : uiImage;

--- a/src/ios/ESMarker.h
+++ b/src/ios/ESMarker.h
@@ -13,7 +13,7 @@
 @interface ESMarker : BasicWidget <MKAnnotation>
 @property (weak) ESMap *map;
 @property (strong) NSArray *position;
-@property (strong) NSArray *image;
+@property (strong) NSObject *image;
 @property (assign) BOOL tapListener;
 - (void)tapped;
 @end

--- a/src/ios/ESMarker.m
+++ b/src/ios/ESMarker.m
@@ -31,14 +31,14 @@
     return self;
 }
 
-- (void)setImage:(NSArray *)image {
-    _image = image;
+- (void)setImage:(NSObject *)image {
+    _image = [image isKindOfClass:[NSArray class]] || [image isKindOfClass:[NSDictionary class]] ? image : nil;
     if (self.map) {
         [self.map refreshMarker:self];
     }
 }
 
-- (NSArray *)image {
+- (NSObject *)image {
     return _image;
 }
 


### PR DESCRIPTION
Modern Tabris.js uses Object type to describe an image. This type was
not supported in this plugin. Only older Array notation was supported.

Issue have been identified when using latest Tabris.js 3.x nightly.
Eiffel tower marker have not been visible on Marker page.