### PR TITLE
Fix `changeCamera` event on iOS

### DIFF
--- a/src/ios/ESMap.m
+++ b/src/ios/ESMap.m
@@ -50,7 +50,7 @@
 @synthesize longpressListener = _longpressListener;
 @synthesize readyListener = _readyListener;
 @synthesize cameraMovedListener = _cameraMovedListener;
-@synthesize changecameraListener = _changecameraListener;
+@synthesize changeCameraListener = _changeCameraListener;
 @synthesize showMyLocation = _showMyLocation;
 
 - (instancetype)initWithObjectId:(NSString *)objectId properties:(NSDictionary *)properties inContext:(id<TabrisContext>)context {
@@ -389,8 +389,8 @@
 }
 
 - (void)mapView:(MKMapView *)mapView regionDidChangeAnimated:(BOOL)animated {
-    if (self.changecameraListener) {
-        [self fireEventNamed:@"changecamera" withAttributes:self.camera];
+    if (self.changeCameraListener) {
+        [self fireEventNamed:@"changeCamera" withAttributes:self.camera];
     }
     if (self.cameraMovedListener && self.gestureWasRecognized) {
         self.gestureWasRecognized = NO;


### PR DESCRIPTION
It looks like iOS sources have not been updated accordingly to:
https://github.com/eclipsesource/tabris-plugin-maps/commit/a72b9c07bc8d5c6b60ecae1f36920f8236723cd9#diff-0a4078aeef290296e4a94427bf50c377c062175b22eaed7e3783c7b8c9638601

fix #73