### PR TITLE
Upgrade Google Maps SDK

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -48,7 +48,7 @@
       <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     </config-file>
 
-    <framework src="com.google.android.gms:play-services-maps:17.0.0" />
+    <framework src="com.google.android.gms:play-services-maps:18.2.0" />
 
     <source-file src="src/android/com/eclipsesource/tabris/maps/CameraProperty.kt"
                  target-dir="src/com/eclipsesource/tabris/maps" />

--- a/project/android/build.gradle
+++ b/project/android/build.gradle
@@ -1,11 +1,14 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext {
+        agp_version = '7.4.2'
+        kotlin_version = '1.7.20'
+    }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath "com.android.tools.build:gradle:$agp_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -13,11 +16,11 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
         maven {
             // provides tabris from directory repository
-            url System.getenv("TABRIS_ANDROID_PLATFORM") + "/bin/templates/project/m2repository"
+            url System.getenv("TABRIS_ANDROID_PLATFORM") + "/templates/project/m2repository"
         }
     }
 }

--- a/project/android/gradle/wrapper/gradle-wrapper.properties
+++ b/project/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 09 17:26:04 CEST 2019
+#Wed Feb 21 12:55:56 AZT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/project/android/maps/build.gradle
+++ b/project/android/maps/build.gradle
@@ -2,18 +2,18 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 dependencies {
-    implementation 'com.eclipsesource.tabris.android:tabris:3.5.0'
-    implementation 'com.google.android.gms:play-services-maps:17.0.0'
+    implementation 'com.eclipsesource.tabris.android:tabris:3.9.0'
+    implementation 'com.google.android.gms:play-services-maps:18.2.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 android {
 
-    compileSdkVersion 29
+    compileSdkVersion 33
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 29
+        minSdkVersion 23
+        targetSdkVersion 33
     }
 
     lintOptions {

--- a/src/android/com/eclipsesource/tabris/maps/MapMarker.kt
+++ b/src/android/com/eclipsesource/tabris/maps/MapMarker.kt
@@ -9,7 +9,7 @@ class MapMarker {
   var position: LatLng? = null
     set(value) {
       field = value
-      marker?.let { it.position = value }
+      marker?.position = value ?: return
     }
 
   var title: String? = null
@@ -34,7 +34,7 @@ class MapMarker {
     set(value) {
       field = value
       value?.let {
-        it.position = position
+        it.position = position ?: return
         it.title = title
         it.setIcon(icon)
         it.snippet = snippet


### PR DESCRIPTION
Google Maps Platform has introduced a new renderer for Maps SDK for Android version 18.0, initially available on an opt-in basis. Starting from version 18.2, it will be the default renderer, with an option to specify the Legacy renderer (Renderer.LEGACY).

Apps built with the Maps SDK for Android will be automatically updated to the latest renderer beginning March 4, 2024. The legacy renderer is scheduled for decommissioning on March 3, 2025.

Update the Google Maps SDK dependency to the latest version for testing the application with the new renderer before the scheduled automatic update in March 2024, in order to limit risks of potential issues.

Additionally, update the Gradle versions and build files to align with the configuration used by the Tabris Android platform.